### PR TITLE
[GEN-177] login API 수정

### DIFF
--- a/account/views/oj.py
+++ b/account/views/oj.py
@@ -259,7 +259,7 @@ class CheckTFARequiredAPI(APIView):
         return self.success({"result": result})
 
 
-class UserLoginAPI(APIView):
+class UserLoginAPI(CSRFExemptAPIView):
     @method_decorator(csrf_exempt)
     @validate_serializer(UserLoginSerializer)
     def post(self, request):

--- a/account/views/oj.py
+++ b/account/views/oj.py
@@ -260,6 +260,7 @@ class CheckTFARequiredAPI(APIView):
 
 
 class UserLoginAPI(APIView):
+    @method_decorator(csrf_exempt)
     @validate_serializer(UserLoginSerializer)
     def post(self, request):
         """


### PR DESCRIPTION
- CSRF 토큰 문제로 로그인 API 데이터 요청 불가
- 임시로 Login API 부분만 CSRF 해제
- 임시적인 해결방법이라 향후 보안을 위해서는 꼭 수정 필요함
  - 클라이언트에서 직접 CSRF 토큰을 얻고 요청하는 방식으로 바꿔야함